### PR TITLE
change index to lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,0 @@
-const ReactStores = require('./lib/index');
-
-module.exports.StoreComponent = ReactStores.StoreComponent;
-module.exports.Store = ReactStores.Store;
-module.exports.followStore = ReactStores.followStore;
-module.exports.StoreEvent = ReactStores.StoreEvent;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"components"
 	],
 	"description": "React direct state stores",
-	"main": "index.js",
+	"main": "lib",
 	"scripts": {
 		"build": "tsc src/store.ts --jsx 'react' -d --outDir './' && mkdir -p ./lib && mv ./store.d.ts ./index.d.ts && mv ./store.js ./lib/index.js",
 		"test": "cd test && webpack --config ./webpack.config.js && cd .. && node_modules/.bin/mocha test/test.js",


### PR DESCRIPTION
I think we do not need anymore to use root index.js as Webpack has already made exports to import it as Typescript module, then you do not have to update your root index.js whenever you make a new functionality